### PR TITLE
Fix config issues preventing Apache starting on CentOS 7

### DIFF
--- a/copyfiles.sh
+++ b/copyfiles.sh
@@ -63,8 +63,10 @@ sed -i "s/\(.*\)$quotedtmpservername\(.*\)/\1$quotedservername\2/" $tomcatconfdi
 if grep -w 'release 7' /etc/redhat-release >/dev/null; then
 
 	templatefn=etc/httpd/conf/esgf-httpd.conf.7.tmpl
+	systemd=true
 else
 	templatefn=etc/httpd/conf/esgf-httpd.conf.6.tmpl
+	systemd=false
 fi
 
 sed "s/\(.*\)$quotedtmpservername\(.*\)/\1$quotedservername\2/" $templatefn >etc/httpd/conf/esgf-httpd.conf;
@@ -80,6 +82,7 @@ bash setup_python.sh "$esgfpython" "$esgfpip";
 cp etc/httpd/conf/esgf-httpd.conf /etc/httpd/conf/
 cp /etc/sysconfig/httpd /etc/sysconfig/httpd-`date +%Y%m%d`;
 cat etc/init.d/ldval >/etc/sysconfig/httpd
+${systemd} && sed -i 's/^export //' /etc/sysconfig/httpd
 #cp usr/local/tomcat/conf/server.xml /usr/local/tomcat/conf/
 mkdir -p /etc/certs
 mkdir -p /opt/esgf/flaskdemo/demo

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -22,6 +22,7 @@ ThreadsPerChild     25
 MaxRequestsPerChild  0
 </IfModule>
 Listen 80
+LoadModule systemd_module modules/mod_systemd.so
 LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -77,7 +77,7 @@ LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
 LoadModule suexec_module modules/mod_suexec.so
-LoadModule cgi_module modules/mod_cgi.so
+LoadModule cgid_module modules/mod_cgid.so
 LoadModule version_module modules/mod_version.so
 LoadModule wsgi_module placeholder_so
 User apache
@@ -151,6 +151,7 @@ SSLRandomSeed startup file:/dev/urandom  256
 SSLRandomSeed connect builtin
 SSLCryptoDevice builtin
 TraceEnable Off
+ScriptSock /var/run/httpd/cgisock
 
 WSGISocketPrefix run/wsgi
 

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -27,6 +27,7 @@ LoadModule auth_basic_module modules/mod_auth_basic.so
 LoadModule auth_digest_module modules/mod_auth_digest.so
 LoadModule authn_file_module modules/mod_authn_file.so
 LoadModule authn_core_module modules/mod_authn_core.so
+LoadModule cache_module modules/mod_cache.so
 LoadModule cache_disk_module modules/mod_cache_disk.so
 
 LoadModule mpm_worker_module modules/mod_mpm_worker.so
@@ -75,7 +76,6 @@ LoadModule proxy_ftp_module modules/mod_proxy_ftp.so
 LoadModule proxy_http_module modules/mod_proxy_http.so
 LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
-LoadModule cache_module modules/mod_cache.so
 LoadModule suexec_module modules/mod_suexec.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule version_module modules/mod_version.so

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -166,15 +166,15 @@ WSGISocketPrefix run/wsgi
 </Location>
 <Location /admin>
 		<RequireAny>
+			#insert-permitted-ips-here
 			Require all denied
 		</RequireAny>
-	#insert-permitted-ips-here
 </Location>
 <Location /solr/admin>
 		<RequireAny>
+			#insert-permitted-ips-here
 			Require all denied
 		</RequireAny>
-	#insert-permitted-ips-here
 </Location>
 <Location /solr/*/update>
 		<RequireAny>

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -42,8 +42,9 @@ LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule ldap_module modules/mod_ldap.so
-LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
+# For LDAP support, install "mod_ldap" package and uncomment lines below.
+#LoadModule ldap_module modules/mod_ldap.so
+#LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so
 LoadModule log_config_module modules/mod_log_config.so
 LoadModule logio_module modules/mod_logio.so

--- a/etc/httpd/conf/esgf-httpd.conf.7.tmpl
+++ b/etc/httpd/conf/esgf-httpd.conf.7.tmpl
@@ -36,13 +36,11 @@ LoadModule authz_core_module modules/mod_authz_core.so
 LoadModule slotmem_shm_module modules/mod_slotmem_shm.so
 LoadModule authn_anon_module modules/mod_authn_anon.so
 LoadModule authn_dbm_module modules/mod_authn_dbm.so
-LoadModule authn_default_module modules/mod_authn_default.so
 LoadModule authz_host_module modules/mod_authz_host.so
 LoadModule authz_user_module modules/mod_authz_user.so
 LoadModule authz_owner_module modules/mod_authz_owner.so
 LoadModule authz_groupfile_module modules/mod_authz_groupfile.so
 LoadModule authz_dbm_module modules/mod_authz_dbm.so
-LoadModule authz_default_module modules/mod_authz_default.so
 LoadModule ldap_module modules/mod_ldap.so
 LoadModule authnz_ldap_module modules/mod_authnz_ldap.so
 LoadModule include_module modules/mod_include.so
@@ -79,7 +77,6 @@ LoadModule proxy_ajp_module modules/mod_proxy_ajp.so
 LoadModule proxy_connect_module modules/mod_proxy_connect.so
 LoadModule cache_module modules/mod_cache.so
 LoadModule suexec_module modules/mod_suexec.so
-LoadModule disk_cache_module modules/mod_disk_cache.so
 LoadModule cgi_module modules/mod_cgi.so
 LoadModule version_module modules/mod_version.so
 LoadModule wsgi_module placeholder_so


### PR DESCRIPTION
After a clean install of ESGF on CentOS 7, Apache fails to start due to a number of
issues in the configuration.